### PR TITLE
Removed socketPath from DB config 

### DIFF
--- a/Db/dbConfig.js
+++ b/Db/dbConfig.js
@@ -1,7 +1,7 @@
 const mysql2 = require("mysql2");
 
 const dbConnection = mysql2.createPool({
-  socketPath: process.env.DB_SOCKET_PATH,
+  // socketPath: process.env.DB_SOCKET_PATH,
   user: process.env.DB_USER,
   password: process.env.DB_PASSWORD,
   host: process.env.DB_HOST,


### PR DESCRIPTION
Removed socketPath from database configuration since all team members use Windows, which does not support Unix socket connections. This change prevents connection issues.
